### PR TITLE
fix for array notation example in #2

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/imports/OrganizeImports.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/imports/OrganizeImports.groovy
@@ -83,7 +83,7 @@ class OrganizeImports extends DefaultTask implements PatternFilterable {
 				if (item.starImport || !removeUnused) {
 					return true
 				} else {
-					Pattern usePattern = ~/(?:^|[\[\{\(<\s,@!])${item.simpleName}(?:[\.\(,\s<>\)\}\]]|::|$)/
+					Pattern usePattern = ~/(?:^|[\[\{\(<\s,@!])${item.simpleName}(?:[\.\(,\s<>\[\)\}\]]|::|$)/
 					return postImportLines.find { line ->
 						usePattern.matcher(line).find()
 					}

--- a/src/test/groovy/org/ajoberstar/gradle/imports/OrganizeImportsTest.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/imports/OrganizeImportsTest.groovy
@@ -98,4 +98,29 @@ public class DoubleColon {
     String result = new String(Files.readAllBytes(sourcePath))
     result.contains("import java.util.Objects;")
   }
+  
+  private String arrayInput = '''\
+package com.example.myapplication;
+
+import java.io.File;
+
+public interface FileLister {
+
+    File[] listFiles();
+
+}
+'''
+  
+  def 'array notation is recognized and import is kept'() {
+    given:
+    def sourcePath = tempDir.newFile('FileLister.java').toPath()
+    Files.write(sourcePath, arrayInput.bytes)
+    def task = ProjectBuilder.builder().build().task('organizeImports', type: OrganizeImports)
+    task.removeUnused = true
+    when:
+    task.organizeFile(sourcePath.toFile(), task.sortOrder.collect { Pattern.compile(it) })
+    then:
+    String result = new String(Files.readAllBytes(sourcePath))
+    result.contains("import java.io.File;")
+  }
 }


### PR DESCRIPTION
recognizes statements like

``` java
File[] files;
```

and does therefore not remove the corresponding `import java.io.File` statement
