### PR TITLE
Add support for exceptions thrown by an interface method

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/imports/OrganizeImports.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/imports/OrganizeImports.groovy
@@ -83,7 +83,7 @@ class OrganizeImports extends DefaultTask implements PatternFilterable {
 				if (item.starImport || !removeUnused) {
 					return true
 				} else {
-					Pattern usePattern = ~/(?:^|[\[\{\(<\s,@!])${item.simpleName}(?:[\.\(,\s<>\[\)\}\]]|::|$)/
+					Pattern usePattern = ~/(?:^|[\[\{\(<\s,@!])${item.simpleName}(?:[\.;\(,\s<>\[\)\}\]]|::|$)/
 					return postImportLines.find { line ->
 						usePattern.matcher(line).find()
 					}

--- a/src/test/groovy/org/ajoberstar/gradle/imports/OrganizeImportsTest.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/imports/OrganizeImportsTest.groovy
@@ -123,4 +123,29 @@ public interface FileLister {
     String result = new String(Files.readAllBytes(sourcePath))
     result.contains("import java.io.File;")
   }
+
+  private String interfaceExceptionInput = '''\
+package com.example.myapplication;
+
+import java.lang.Exception;
+
+public interface MyInterface {
+
+    void throwsException() throws Exception;
+
+}
+'''
+
+  def 'exceptions thrown by an interface method are recognized and kept'() {
+    given:
+    def sourcePath = tempDir.newFile('MyInterface.java').toPath()
+    Files.write(sourcePath, interfaceExceptionInput.bytes)
+    def task = ProjectBuilder.builder().build().task('organizeImports', type: OrganizeImports)
+    task.removeUnused = true
+    when:
+    task.organizeFile(sourcePath.toFile(), task.sortOrder.collect { Pattern.compile(it) })
+    then:
+    String result = new String(Files.readAllBytes(sourcePath))
+    result.contains("import java.lang.Exception;")
+  }
 }


### PR DESCRIPTION
Exceptions thrown by an interface method were removed because the exception name is followed by a semicolon (which is not included in the pattern to find the imports).
